### PR TITLE
Fix group shuffle setting for 13 battle rando

### DIFF
--- a/FF13Rando/Randomizers/BattleRando.cs
+++ b/FF13Rando/Randomizers/BattleRando.cs
@@ -258,9 +258,9 @@ public class BattleRando : Randomizer
                         {
                             string peerEnemy = RandomNum.SelectRandom(enemiesToAddToSet);
                             string charaspecToAdd = enemyRando.btCharaSpec[peerEnemy].sCharaSpec_string;
-                            if (!peerList.Contains(peerEnemy))
+                            if (!peerList.Contains(charaspecToAdd))
                             {
-                                peerList.Add(peerEnemy);
+                                peerList.Add(charaspecToAdd);
                             }
                         }
                         // Make sure we update the available amount remaining for a peer fill
@@ -345,8 +345,8 @@ public class BattleRando : Randomizer
                     List<string> dataCharsets = data.Charasets;
                     //Resolve all modified charasets available for this battle and take the intersection as enemy candidates.
                     List<List<string>> charasetEnemyGroups = dataCharsets.Select(cs => charaSets[cs].GetCharaSpecs()).ToList();
-                    List<string> intersectionGroup = charasetEnemyGroups.Aggregate(charasetEnemyGroups[0], (a, b) => a.Intersect(b).ToList());
-                    btscs[id].Values.Shuffle().Where(e => intersectionGroup.Contains(e.sEntryBtChSpec_string)).ForEach(e =>
+                    List<string> intersectionGroup = charasetEnemyGroups.Aggregate((IEnumerable<string>)charasetEnemyGroups[0], (a, b) => a.Intersect(b)).ToList();
+                    btscs[id].Values.Shuffle().Where(e => intersectionGroup.Contains(enemyRando.btCharaSpec[e.sEntryBtChSpec_string].sCharaSpec_string)).ForEach(e =>
                     {
                         // List the old enemy
                         string oldEnemy = e.sEntryBtChSpec_string;
@@ -373,7 +373,7 @@ public class BattleRando : Randomizer
                     //Extract all battles for a given charaset.
                     List<string> battles = battleData.Where(battle => battle.Value.Charasets.Contains(charaset)).Select(b => b.Key).ToList();
                     //Extract all used enemies from battles
-                    List<string> used = battles.SelectMany(b => btscs[b].Values.Select(e => e.sEntryBtChSpec_string)).Distinct().ToList();
+                    List<string> used = battles.SelectMany(b => btscs[b].Values.Select(e => enemyRando.btCharaSpec[e.sEntryBtChSpec_string].sCharaSpec_string)).Distinct().ToList();
                     //Union all required enemies from battles with the original contents of the character set
                     //TODO: When we can update field models, this can be more aggressive to remove unused enemies.
                     charaSets[charaset].SetCharaSpecs(used.Union(original).Distinct().ToList());

--- a/FF13Rando/Randomizers/BattleRando.cs
+++ b/FF13Rando/Randomizers/BattleRando.cs
@@ -68,6 +68,8 @@ public class BattleRando : Randomizer
                 btsc.Load("13", path, SetupData.Paths["Nova"]);
                 btscs.TryAdd(Path.GetFileNameWithoutExtension(path), btsc);
             });
+            //Encounter containing chieftain and 4 _Display_ goblins - seems to be unused
+            btscs.Remove("btsc11457", out _);
         }
 
         Randomizers.SetUIProgress("Loading Battle Data...", 90, 100);
@@ -341,11 +343,16 @@ public class BattleRando : Randomizer
                 List<string> multiCharasetBattles = battleData.Where(battle => battle.Value.Charasets.Count > 1).Select(battle => battle.Key).ToList();
                 multiCharasetBattles.Shuffle().ForEach(id =>
                 {
+                    // Battle is unused and contains invalid data.
+                    if(id == "btsc11457")
+                    {
+                        return;
+                    }
                     BattleData data = battleData[id];
                     List<string> dataCharsets = data.Charasets;
                     //Resolve all modified charasets available for this battle and take the intersection as enemy candidates.
                     List<List<string>> charasetEnemyGroups = dataCharsets.Select(cs => charaSets[cs].GetCharaSpecs()).ToList();
-                    List<string> intersectionGroup = charasetEnemyGroups.Aggregate((IEnumerable<string>)charasetEnemyGroups[0], (a, b) => a.Intersect(b)).ToList();
+                    List<string> intersectionGroup = charasetEnemyGroups.Aggregate((IEnumerable<string>)charasetEnemyGroups[0], (a, b) => a.Intersect(b)).Where(e => enemyData.ContainsKey(e)).ToList();
                     btscs[id].Values.Shuffle().Where(e => intersectionGroup.Contains(enemyRando.btCharaSpec[e.sEntryBtChSpec_string].sCharaSpec_string)).ForEach(e =>
                     {
                         // List the old enemy

--- a/FF13Rando/Randomizers/BattleRando.cs
+++ b/FF13Rando/Randomizers/BattleRando.cs
@@ -327,7 +327,7 @@ public class BattleRando : Randomizer
                             if (possible.Count > 0)
                             {
                                 //Select a new random enemy from the list
-                                e.sEntryBtChSpec_string = RandomNum.SelectRandomWeighted(possible, _ => 1);
+                                e.sEntryBtChSpec_string = RandomNum.SelectRandom(possible);
                             }
                             else
                             {
@@ -355,7 +355,7 @@ public class BattleRando : Randomizer
                         if (possible.Count > 0)
                         {
                             //Select a new random enemy from the list if we have any to save
-                            e.sEntryBtChSpec_string = RandomNum.SelectRandomWeighted(possible, _ => 1);
+                            e.sEntryBtChSpec_string = RandomNum.SelectRandom(possible);
                         }
                         else
                         {
@@ -400,7 +400,7 @@ public class BattleRando : Randomizer
                           {
                               canAdd = true;
                               //Select a new random enemy from the list
-                              e.sEntryBtChSpec_string = RandomNum.SelectRandomWeighted(possible, _ => 1);
+                              e.sEntryBtChSpec_string = RandomNum.SelectRandom(possible);
                               //If its in the vanilla set then we good, move on.
                               if (vanillaEnemies.Contains(e.sEntryBtChSpec_string))
                               {

--- a/FF13Rando/bin/data/battlescenes.csv
+++ b/FF13Rando/bin/data/battlescenes.csv
@@ -750,7 +750,6 @@ btsc14450,,Archylte Steppe,chset_z023_de8b|chset_z023_def8,
 btsc14451,,Archylte Steppe,chset_z023_de8b|chset_z023_def8,
 btsc11448,,Archylte Steppe,chset_z023_de8b|chset_z023_def8,
 btsc14447,,Archylte Steppe,chset_z023_de8b|chset_z023_def8,
-btsc11457,,Archylte Steppe,chset_z023_de8b|chset_z023_def8,Mission
 btsc14446,Mission 13 maybe,Archylte Steppe,chset_z023_de8b|chset_z023_def8,Mission
 btsc11277,,Archylte Steppe,chset_z023_def1|chset_z023_def4,
 btsc11259,,Archylte Steppe,chset_z023_def4,


### PR DESCRIPTION
Ensure groups with only shared battles are treated differently Add cleanup step to remove unused enemy defs from charaspecs